### PR TITLE
Fix version_check URL in swinfo.json

### DIFF
--- a/maneuver_node_controller/swinfo.json
+++ b/maneuver_node_controller/swinfo.json
@@ -5,7 +5,7 @@
   "description": "Provides an interface to finely tune maneuver nodes",
   "source": "https://github.com/XYZ3211/ManeuverNodeController",
   "version": "0.9.2",
-  "version_check": "https://raw.githubusercontent.com/schlosrat/ManeuverNodeController/master/maneuver_node_controller/swinfo.json",
+  "version_check": "https://raw.githubusercontent.com/schlosrat/ManeuverNodeController/main/maneuver_node_controller/swinfo.json",
   "dependencies": [
     {
       "id": "SpaceWarp",


### PR DESCRIPTION
Hi @schlosrat,

#10 added a `version_check` URL, but it uses the branch name `master`, and this repo uses `main` instead. GitHub's web UI will auto redirect for that specific case, but if someone tries to access it via the GitHub API (as the CKAN bot does in order to use its auth token and avoid being throttled), it fails. That's why this mod's latest release hasn't been added to CKAN.

Now it's fixed. Cheers!
